### PR TITLE
Using new builder, place errors resolved

### DIFF
--- a/castles.ts
+++ b/castles.ts
@@ -1,5 +1,7 @@
 //% color="#AA278D" icon="\uf447" weight=54
 namespace castles {
+
+    const _castleBuilder = new builder.Builder();
     /**
      * Build a castle wall of specified width, length, and height out of blockType
      * @param width how thick the wall will be. If at least 3, there will be a gap for inner and outer walls
@@ -28,21 +30,21 @@ namespace castles {
         position?: Position
         ) {
         if (position) {
-            builder.shift(
+            _castleBuilder.shift(
                 position.getValue(Axis.X) - Math.floor(width / 2),
                 position.getValue(Axis.Y),
                 position.getValue(Axis.Z) - Math.floor(width / 2)
             )
         } else {
-            builder.shift(- Math.floor(width / 2), 0, - Math.floor(width / 2))
+            _castleBuilder.shift(- Math.floor(width / 2), 0, - Math.floor(width / 2))
         }
         // build 2 walls from bottom to top (up to WallHeight)
         for (let index4 = 0; index4 < height - 1; index4++) {
             drawRectangle(length, width, blockType)
-            builder.move(UP, 1)
+            _castleBuilder.move(UP, 1)
         }
         drawAlternatingRectangle(length - 2, width - 2, blockType)
-        builder.shift(length - Math.floor(width / 2) - 1, 1 - height, Math.floor(width / 2))
+        _castleBuilder.shift(length - Math.floor(width / 2) - 1, 1 - height, Math.floor(width / 2))
     }
 
     /**
@@ -65,25 +67,25 @@ namespace castles {
     //% help=github:makecode-minecraft-castle-builder/docs/castle-tower
     export function buildCastleTower(width: number, height: number, blockType: number, position?: Position) {
         if (position) {
-            builder.shift(
+            _castleBuilder.shift(
                 position.getValue(Axis.X) - Math.floor(width / 2),
                 position.getValue(Axis.Y),
                 position.getValue(Axis.Z) - Math.floor(width / 2)
             )
         } else {
-            builder.shift(- Math.floor(width / 2), 0, - Math.floor(width / 2))
+            _castleBuilder.shift(- Math.floor(width / 2), 0, - Math.floor(width / 2))
         }
         // build tower base
         buildTower(width, height, blockType);
         // build the look-out part, larger by 1 (the shift)
-        builder.shift(-1, 0, -1)
+        _castleBuilder.shift(-1, 0, -1)
         buildTower(width + 2, 2, blockType);
 
         // build battlement part
         drawAlternatingRectangle(width, width, blockType)
 
         // mov builder back to center
-        builder.shift(Math.floor(width / 2) + 1, 0 - (height + 4), Math.floor(width / 2) + 1)
+        _castleBuilder.shift(Math.floor(width / 2) + 1, 0 - (height + 4), Math.floor(width / 2) + 1)
     }
 
     /**
@@ -100,11 +102,11 @@ namespace castles {
     export function buildSimpleCastle(blockType: number, position?: Position) {
         let teleportPos = position ? position : player.position();
         // move builder back to player position to allow repeat usage
-        builder.teleportTo(teleportPos)
+        _castleBuilder.teleportTo(teleportPos)
         // start off facing left of the player
-        builder.face(getDirectionLeftOfPlayer())
+        _castleBuilder.face(getDirectionLeftOfPlayer())
         // shift away from player
-        builder.shift(-13, 0, -13)
+        _castleBuilder.shift(-13, 0, -13)
 
         buildCastle(blockType);
     }
@@ -123,14 +125,14 @@ namespace castles {
     //% help=github:makecode-minecraft-castle-builder/docs/sky-castle
     export function buildCastleInTheSky(blockType: number, beanstalk?: boolean, position?: Position) {
         let teleportPos = position ? position : player.position()
-        builder.teleportTo(teleportPos)
-        builder.face(getDirectionLeftOfPlayer())
-        builder.turn(RIGHT_TURN)
+        _castleBuilder.teleportTo(teleportPos)
+        _castleBuilder.face(getDirectionLeftOfPlayer())
+        _castleBuilder.turn(RIGHT_TURN)
 
-        builder.shift(24, 20, 0);
-        const cloudCenter = builder.position();
+        _castleBuilder.shift(24, 20, 0);
+        const cloudCenter = _castleBuilder.position();
         shapes.circle(Block.Wool, cloudCenter, 23, Axis.Y, ShapeOperation.Replace)
-        builder.shift(-13, 1, -13)
+        _castleBuilder.shift(-13, 1, -13)
 
         buildCastle(blockType);
         if (beanstalk) {
@@ -173,7 +175,7 @@ namespace castles {
     function buildTower(width: number, height: number, blockType: number) {
         for (let index = 0; index <= height; index++) {
             drawRectangle(width, width, blockType);
-            builder.move(UP, 1)
+            _castleBuilder.move(UP, 1)
         }
     }
 
@@ -184,9 +186,11 @@ namespace castles {
      */
     function buildCastle(blockType: number) {
         for (let index = 0; index < 4; index++) {
+            player.say("tower");
             buildCastleTower(5, 8, blockType);
+            player.say("wall");
             buildCastleWall(3, 27, 6, blockType);
-            builder.turn(LEFT_TURN);
+            _castleBuilder.turn(LEFT_TURN);
         }
     }
 
@@ -196,10 +200,10 @@ namespace castles {
      * @param blockType the Minecraft block the line will be built with
      */
     function drawLine(length: number, blockType: number) {
-        builder.mark()
-        builder.move(FORWARD, length - 1)
-        builder.tracePath(blockType)
-        builder.turn(LEFT_TURN)
+        _castleBuilder.mark()
+        _castleBuilder.move(FORWARD, length - 1)
+        _castleBuilder.tracePath(blockType)
+        _castleBuilder.turn(LEFT_TURN)
     }
 
     /**
@@ -225,9 +229,9 @@ namespace castles {
     function drawAlternatingLine(length: number, start: boolean, blockType: number): boolean {
         let placeBlock = start;
         for (let index2 = 0; index2 <= length; index2 ++) {
-            builder.move(FORWARD, 1);
+            _castleBuilder.move(FORWARD, 1);
             if (placeBlock) {
-                builder.place(blockType);
+                _castleBuilder.place(blockType);
             }
             placeBlock = !placeBlock
         }
@@ -243,9 +247,9 @@ namespace castles {
     function drawAlternatingRectangle(length: number, width: number, blockType: number) {
         for (let index3 = 0; index3 < 2; index3++) {
             let putBlock = drawAlternatingLine(length, false, blockType);
-            builder.turn(LEFT_TURN);
+            _castleBuilder.turn(LEFT_TURN);
             drawAlternatingLine(width, putBlock, blockType);
-            builder.turn(LEFT_TURN);
+            _castleBuilder.turn(LEFT_TURN);
         }
     }
 

--- a/castles.ts
+++ b/castles.ts
@@ -13,7 +13,7 @@ namespace castles {
     //% block="build castle wall|made of $blockType width $width length $length height $height||at position $position"
     //% width.defl=3
     //% width.min=2 width.max=1000
-    //% length.defl=27
+    //% length.defl=21
     //% length.min=4 length.max=1000
     //% height.defl=6
     //% height.min=1 height.max=1000
@@ -44,7 +44,7 @@ namespace castles {
             _castleBuilder.move(UP, 1)
         }
         drawAlternatingRectangle(length - 2, width - 2, blockType)
-        _castleBuilder.shift(length - Math.floor(width / 2) - 1, 1 - height, Math.floor(width / 2))
+        _castleBuilder.shift(length + 2, 1 - height, Math.floor(width / 2))
     }
 
     /**
@@ -84,8 +84,8 @@ namespace castles {
         // build battlement part
         drawAlternatingRectangle(width, width, blockType)
 
-        // mov builder back to center
-        _castleBuilder.shift(Math.floor(width / 2) + 1, 0 - (height + 4), Math.floor(width / 2) + 1)
+        // move builder back to center edge
+        _castleBuilder.shift(width + 2, 0 - (height + 4), Math.floor(width / 2) + 1)
     }
 
     /**
@@ -186,10 +186,8 @@ namespace castles {
      */
     function buildCastle(blockType: number) {
         for (let index = 0; index < 4; index++) {
-            player.say("tower");
             buildCastleTower(5, 8, blockType);
-            player.say("wall");
-            buildCastleWall(3, 27, 6, blockType);
+            buildCastleWall(3, 21, 6, blockType);
             _castleBuilder.turn(LEFT_TURN);
         }
     }

--- a/castles.ts
+++ b/castles.ts
@@ -106,10 +106,11 @@ namespace castles {
      * @param blockType the Minecraft block the castle will be built with
      */
     //% blockId=castles_build_sky_castle
-    //% block="build a castle in the sky made of $blockType || with beanstalk $beanstalk||at position $position"
+    //% block="build a castle in the sky made of $blockType || at position $position with beanstalk $beanstalk "
     //% blockType.shadow=minecraftBlock
     //% blockType.defl=Block.Cobblestone
     //% beanstalk.defl=false
+    //% position.shadow=minecraftCreatePosition
     //% weight=150
     //% help=github:makecode-minecraft-castle-builder/docs/sky-castle
     export function buildCastleInTheSky(blockType: number, beanstalk?: boolean, position?: Position) {

--- a/castles.ts
+++ b/castles.ts
@@ -17,7 +17,7 @@ namespace castles {
     //% height.min=1 height.max=1000
     //% blockType.shadow=minecraftBlock
     //% blockType.defl=Block.Cobblestone
-    //% position.shadow=minecraftCreatePosition
+    //% position.shadow=minecraftCreatePositionCamera
     //% weight=340
     //% help=github:makecode-minecraft-castle-builder/docs/castle-wall
     export function buildCastleWall(
@@ -28,7 +28,11 @@ namespace castles {
         position?: Position
         ) {
         if (position) {
-            builder.shift(position.getValue(Axis.X) - Math.floor(width / 2), 0, position.getValue(Axis.Z) - Math.floor(width / 2))
+            builder.shift(
+                position.getValue(Axis.X) - Math.floor(width / 2),
+                position.getValue(Axis.Y),
+                position.getValue(Axis.Z) - Math.floor(width / 2)
+            )
         } else {
             builder.shift(- Math.floor(width / 2), 0, - Math.floor(width / 2))
         }
@@ -56,12 +60,16 @@ namespace castles {
     //% blockType.shadow=minecraftBlock
     //% blockType.defl=Block.Cobblestone
     //% inlineInputMode="external"
-    //% position.shadow=minecraftCreatePosition
+    //% position.shadow=minecraftCreatePositionCamera
     //% weight=350
     //% help=github:makecode-minecraft-castle-builder/docs/castle-tower
     export function buildCastleTower(width: number, height: number, blockType: number, position?: Position) {
         if (position) {
-            builder.shift(position.getValue(Axis.X) - Math.floor(width / 2), 0, position.getValue(Axis.Z) - Math.floor(width / 2))
+            builder.shift(
+                position.getValue(Axis.X) - Math.floor(width / 2),
+                position.getValue(Axis.Y),
+                position.getValue(Axis.Z) - Math.floor(width / 2)
+            )
         } else {
             builder.shift(- Math.floor(width / 2), 0, - Math.floor(width / 2))
         }
@@ -86,7 +94,7 @@ namespace castles {
     //% block="build a simple castle made of $blockType||at position $position"
     //% blockType.shadow=minecraftBlock
     //% blockType.defl=Block.Cobblestone
-    //% position.shadow=minecraftCreatePosition
+    //% position.shadow=minecraftCreatePositionCamera
     //% weight=250
     //% help=github:makecode-minecraft-castle-builder/docs/simple-castle
     export function buildSimpleCastle(blockType: number, position?: Position) {
@@ -110,7 +118,7 @@ namespace castles {
     //% blockType.shadow=minecraftBlock
     //% blockType.defl=Block.Cobblestone
     //% beanstalk.defl=false
-    //% position.shadow=minecraftCreatePosition
+    //% position.shadow=minecraftCreatePositionCamera
     //% weight=150
     //% help=github:makecode-minecraft-castle-builder/docs/sky-castle
     export function buildCastleInTheSky(blockType: number, beanstalk?: boolean, position?: Position) {
@@ -137,7 +145,7 @@ namespace castles {
      */
     //% blockId=castles_grow_bean_stalk
     //% block="grow a bean stalk with height $height at $position"
-    //% position.shadow=minecraftCreatePosition
+    //% position.shadow=minecraftCreatePositionCamera
     //% height.defl=20
     //% weight=145
     //% help=github:makecode-minecraft-castle-builder/docs/bean-stalk

--- a/castles.ts
+++ b/castles.ts
@@ -1,4 +1,4 @@
-//% color="#AA278D" icon="\uf447"
+//% color="#AA278D" icon="\uf447" weight=54
 namespace castles {
     /**
      * Build a castle wall of specified width, length, and height out of blockType
@@ -8,7 +8,7 @@ namespace castles {
      * @param blockType the Minecraft block the wall will be built with
      */
     //% blockId=castles_build_wall
-    //% block="build castle wall|made of $blockType width $width length $length height $height" 
+    //% block="build castle wall|made of $blockType width $width length $length height $height||at position $position"
     //% width.defl=3
     //% width.min=2 width.max=1000
     //% length.defl=27
@@ -17,10 +17,21 @@ namespace castles {
     //% height.min=1 height.max=1000
     //% blockType.shadow=minecraftBlock
     //% blockType.defl=Block.Cobblestone
+    //% position.shadow=minecraftCreatePosition
     //% weight=340
     //% help=github:makecode-minecraft-castle-builder/docs/castle-wall
-    export function buildCastleWall(width: number, length: number, height: number, blockType: number) {
-        builder.shift(-Math.floor(width / 2), 0, -Math.floor(width / 2))
+    export function buildCastleWall(
+        width: number,
+        length: number,
+        height: number,
+        blockType: number,
+        position?: Position
+        ) {
+        if (position) {
+            builder.shift(position.getValue(Axis.X) - Math.floor(width / 2), 0, position.getValue(Axis.Z) - Math.floor(width / 2))
+        } else {
+            builder.shift(- Math.floor(width / 2), 0, - Math.floor(width / 2))
+        }
         // build 2 walls from bottom to top (up to WallHeight)
         for (let index4 = 0; index4 < height - 1; index4++) {
             drawRectangle(length, width, blockType)
@@ -37,7 +48,7 @@ namespace castles {
      * @param blockType the Minecraft block the tower will be built with
      */
     //% blockId=castles_build_tower
-    //% block="build castle tower|made of $blockType width $width height $height"
+    //% block="build castle tower|made of $blockType width $width height $height||at position $position"
     //% width.defl=5
     //% width.min=2 width.max=1000
     //% height.defl=8
@@ -45,10 +56,15 @@ namespace castles {
     //% blockType.shadow=minecraftBlock
     //% blockType.defl=Block.Cobblestone
     //% inlineInputMode="external"
+    //% position.shadow=minecraftCreatePosition
     //% weight=350
     //% help=github:makecode-minecraft-castle-builder/docs/castle-tower
-    export function buildCastleTower(width: number, height: number, blockType: number) {
-        builder.shift(- Math.floor(width / 2), 0, - Math.floor(width / 2))
+    export function buildCastleTower(width: number, height: number, blockType: number, position?: Position) {
+        if (position) {
+            builder.shift(position.getValue(Axis.X) - Math.floor(width / 2), 0, position.getValue(Axis.Z) - Math.floor(width / 2))
+        } else {
+            builder.shift(- Math.floor(width / 2), 0, - Math.floor(width / 2))
+        }
         // build tower base
         buildTower(width, height, blockType);
         // build the look-out part, larger by 1 (the shift)
@@ -67,15 +83,16 @@ namespace castles {
      * @param blockType the Minecraft block the castle will be built with
      */
     //% blockId=castles_build_simple_castle
-    //% block="build a simple castle made of $blockType"
+    //% block="build a simple castle made of $blockType||at position $position"
     //% blockType.shadow=minecraftBlock
     //% blockType.defl=Block.Cobblestone
+    //% position.shadow=minecraftCreatePosition
     //% weight=250
     //% help=github:makecode-minecraft-castle-builder/docs/simple-castle
-    export function buildSimpleCastle(blockType: number) {
-        let originalPlayerPosition = player.position()
+    export function buildSimpleCastle(blockType: number, position?: Position) {
+        let teleportPos = position ? position : player.position();
         // move builder back to player position to allow repeat usage
-        builder.teleportTo(originalPlayerPosition)
+        builder.teleportTo(teleportPos)
         // start off facing left of the player
         builder.face(getDirectionLeftOfPlayer())
         // shift away from player
@@ -89,15 +106,15 @@ namespace castles {
      * @param blockType the Minecraft block the castle will be built with
      */
     //% blockId=castles_build_sky_castle
-    //% block="build a castle in the sky made of $blockType || with beanstalk $beanstalk"
+    //% block="build a castle in the sky made of $blockType || with beanstalk $beanstalk||at position $position"
     //% blockType.shadow=minecraftBlock
     //% blockType.defl=Block.Cobblestone
     //% beanstalk.defl=false
     //% weight=150
     //% help=github:makecode-minecraft-castle-builder/docs/sky-castle
-    export function buildCastleInTheSky(blockType: number, beanstalk?: boolean) {
-        let originalPlayerPosition = player.position()
-        builder.teleportTo(originalPlayerPosition)
+    export function buildCastleInTheSky(blockType: number, beanstalk?: boolean, position?: Position) {
+        let teleportPos = position ? position : player.position()
+        builder.teleportTo(teleportPos)
         builder.face(getDirectionLeftOfPlayer())
         builder.turn(RIGHT_TURN)
 


### PR DESCRIPTION
In order to avoid builder collisions that @riknoll pointed out, the castle builder is now using it's local version of the builder. 

I was also able to see where the `could not place` blocks errors were coming from. When we are done building the towers and walls, the builder got shifted back to the center of towers and a different position for walls. This meant that when simple castles were built, there were some instances where overlapping was happening and those few instances would then throw errors. I've now made sure that the shifts that happen at the end of those structures getting built don't overlap.

Note to the issue that this PR addresses: I didn't try this underwater, but I was getting the same errors above water, so I'm figuring I fixed the root issue. 

Fixes https://github.com/microsoft/makecode-minecraft-castle-builder/issues/3