### PR TITLE
Castle in the sky bug: Move position to the correct parameter spot

### DIFF
--- a/castles.ts
+++ b/castles.ts
@@ -123,7 +123,7 @@ namespace castles {
     //% position.shadow=minecraftCreatePositionCamera
     //% weight=150
     //% help=github:makecode-minecraft-castle-builder/docs/sky-castle
-    export function buildCastleInTheSky(blockType: number, beanstalk?: boolean, position?: Position) {
+    export function buildCastleInTheSky(blockType: number, position?: Position, beanstalk?: boolean) {
         let teleportPos = position ? position : player.position()
         _castleBuilder.teleportTo(teleportPos)
         _castleBuilder.face(getDirectionLeftOfPlayer())


### PR DESCRIPTION
Position wasn't working for building castles in the sky. That's because `position` was in the wrong spot in the parameter list. In the block, we have `position` defined as the second parameter while in the function, it was the third parameter. Now that `position` is in the correct second spot, it changes the position of the castle in the sky as expected.

Fixes https://github.com/microsoft/pxt-minecraft/issues/2514